### PR TITLE
threadloom rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,103 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# ThreadLoom
+
+ThreadLoom is a full-stack community discussion platform. Members authenticate with Clerk, join or create communities, and publish long-form threads that unfold into rich, nested conversations. Clerk organization webhooks stay in sync with ThreadLoom’s MongoDB models so memberships, communities, and activity streams stay consistent without manual bookkeeping.
+
+## Features
+- **Personalized feed** – server-side rendered timeline of threads from people and communities you follow.
+- **Community workspaces** – Clerk organizations map directly to ThreadLoom communities (name, slug, logo, members).
+- **Thread composer** – validated forms powered by React Hook Form + Zod for posts and replies.
+- **Nested conversations** – unlimited depth via parent/child thread relationships and recursive rendering.
+- **Discovery tools** – search for users or communities with debounced filtering and pagination.
+- **Role-aware layout** – shared top/bottom/side bars with Clerk-aware links and sign-out controls.
+
+## Tech Stack
+- [Next.js 14 (App Router)](https://nextjs.org/)
+- [React 18](https://react.dev/)
+- [TypeScript](https://www.typescriptlang.org/)
+- [Clerk](https://clerk.com/) for auth, orgs, and session management
+- [MongoDB + Mongoose](https://mongoosejs.com/) for persistence
+- [Tailwind CSS](https://tailwindcss.com/) for styling
+- [UploadThing](https://uploadthing.com/) for media uploads
+- [Zod](https://zod.dev/) + [React Hook Form](https://react-hook-form.com/) for robust form validation
+
+## Architecture Overview
+
+```mermaid
+flowchart LR
+    A[Next.js App Router<br/>Server Components] -->|Server Actions| B[(MongoDB + Mongoose)]
+    A -->|Authentication + Orgs| C[Clerk]
+    C -->|Webhooks via Svix| D[/API Route<br/>/api/webhook/clerk/]
+    D -->|Sync Communities| B
+    A -->|Media Uploads| E[UploadThing]
+    subgraph Client
+        F[React Components]
+    end
+    F -->|Calls| A
+```
 
 ## Getting Started
 
-First, run the development server:
+1. **Install dependencies**
+   ```bash
+   npm install
+   # or
+   yarn
+   ```
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
+2. **Create environment vars**  
+   Copy `.env.example` (if present) or create `.env.local` and supply the secrets below:
+   ```
+   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=...
+   CLERK_SECRET_KEY=...
+   NEXT_CLERK_WEBHOOK_SECRET=...
+   MONGODB_URL=mongodb+srv://...
+   UPLOADTHING_SECRET=...
+   UPLOADTHING_APP_ID=...
+   ```
+
+3. **Run the dev server**
+   ```bash
+   npm run dev
+   ```
+   Visit `http://localhost:3000`.
+
+4. **Webhook tunnel (optional)**  
+   If you test Clerk webhooks locally, expose your dev server via `ngrok` and register the public URL inside the Clerk dashboard pointing to `/api/webhook/clerk`.
+
+## Available Scripts
+- `npm run dev` – start the Next.js dev server
+- `npm run build` – create a production build
+- `npm run start` – serve the built app
+- `npm run lint` – run ESLint with Next.js config
+
+## Project Structure Highlights
+```
+app/                   # Next.js routes (App Router)
+  (auth)/              # Onboarding + auth-only layout
+  (root)/              # Auth-protected app shell
+  api/                 # Route handlers (webhooks, uploadthing, ...)
+components/
+  cards/, forms/, shared/...
+lib/
+  actions/             # Server actions (users, threads, communities)
+  models/              # Mongoose schemas
+  validations/         # Zod schemas
+public/assets/         # Icons + logos
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Deployment
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+ThreadLoom is optimized for [Vercel](https://vercel.com/). Set all required environment variables in your hosting provider, enable the Clerk production instance, and point the webhook URL to your deployed `/api/webhook/clerk` endpoint.
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+## Contributing
 
-## Learn More
+We welcome improvements of any size:
+1. Fork the repo and create a topic branch (`git checkout -b feature/your-idea`).
+2. Implement the change, add/update tests when relevant, and run `npm run lint`.
+3. Open a pull request describing the motivation, screenshots (for UI), and validation steps.
 
-To learn more about Next.js, take a look at the following resources:
+Have a bigger feature in mind? Start with an issue so we can align on direction before you build.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+---
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
-# sutram
+Questions or suggestions? Open an issue or start a thread inside ThreadLoom!

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -2,17 +2,20 @@ import { ClerkProvider } from '@clerk/nextjs';
 import type { Metadata } from 'next';
 
 import '../globals.css';
+import { Inter } from 'next/font/google';
 
 export const metadata: Metadata = {
     title: 'ThreadLoom',
     description: 'ThreadLoom • Community discussions woven together'
 };
 
+const inter = Inter({ subsets: ['latin'] });
+
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
     return (
         <ClerkProvider>
             <html lang="en">
-                <body className={`{inter.className} bg-dark-1`}>
+                <body className={`${inter.className} bg-dark-1`}>
                     <div className="w-full flex justify-center items-center min-h-screen">{children}</div>
                 </body>
             </html>

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -4,8 +4,8 @@ import type { Metadata } from 'next';
 import '../globals.css';
 
 export const metadata: Metadata = {
-    title: 'Sutra',
-    description: 'A NextJS 13 Application'
+    title: 'ThreadLoom',
+    description: 'ThreadLoom • Community discussions woven together'
 };
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {

--- a/app/(auth)/onboard/page.tsx
+++ b/app/(auth)/onboard/page.tsx
@@ -22,7 +22,7 @@ const Page = async () => {
     return (
         <main className="mx-auto flex max-w-3xl flex-col justify-start px-10 py-20">
             <h1 className="head-text">Onboarding</h1>
-            <p className="mt-3 text-base-regular text-light-2">Complete your profile now to use Sutram</p>
+            <p className="mt-3 text-base-regular text-light-2">Complete your profile now to use ThreadLoom</p>
             <section className="mt-9 bg-dark-2 p-10">
                 <AccountProfile user={userData} btnTitle="Continue" />
             </section>

--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -12,8 +12,8 @@ import Topbar from '@/components/shared/Topbar';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-    title: 'Sutra',
-    description: 'A NextJS 13 Application'
+    title: 'ThreadLoom',
+    description: 'ThreadLoom • Community discussions woven together'
 };
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {

--- a/components/shared/Topbar.tsx
+++ b/components/shared/Topbar.tsx
@@ -8,7 +8,7 @@ const Topbar = () => {
         <nav className="topbar">
             <Link href="/" className="flex items-center gap-4">
                 <Image src="/assets/logo.svg" alt="logo" width={28} height={28} />
-                <p className="text-heading3-bold text-light-1 max-xs:hidden">Sutra</p>
+                <p className="text-heading3-bold text-light-1 max-xs:hidden">ThreadLoom</p>
             </Link>
             <div className="flex items-center gap-1">
                 <div className="block md:hidden">

--- a/components/shared/Topbar.tsx
+++ b/components/shared/Topbar.tsx
@@ -24,7 +24,24 @@ const Topbar = () => {
                     appearance={{
                         baseTheme: dark,
                         elements: {
-                            organizationSwitcherTrigger: 'py-2 px-4'
+                            organizationSwitcherTrigger:
+                                'py-2 px-4 bg-dark-3 text-light-1 border border-dark-4 hover:bg-dark-2 transition data-[state=open]:bg-dark-2 data-[state=open]:text-light-1 data-[active=true]:text-light-1 !text-light-1',
+                            organizationSwitcherTriggerIcon:
+                                'text-light-1 group-hover:text-light-1 data-[state=open]:text-light-1 data-[active=true]:text-light-1 !text-light-1',
+                            organizationSwitcherTriggerText:
+                                'text-light-1 hover:text-light-1 data-[state=open]:text-light-1 data-[active=true]:text-light-1 !text-light-1',
+                            organizationSwitcherPopoverCard: 'bg-dark-3 border border-dark-4 text-light-1',
+                            organizationSwitcherPopoverHeader: 'text-light-1',
+                            organizationSwitcherPopoverText: 'text-light-1',
+                            organizationSwitcherPopoverSubtitle: 'text-light-2',
+                            organizationSwitcherPopoverItem: 'text-light-1 hover:bg-dark-2',
+                            organizationSwitcherPopoverActionButton:
+                                'text-light-1 hover:bg-dark-2 border border-dark-4',
+                            organizationSwitcherPopoverCreateOrganization:
+                                'text-light-1 hover:bg-dark-2 border border-dark-4',
+                            organizationSwitcherPopoverManageOrganization:
+                                'text-light-1 hover:bg-dark-2 border border-dark-4',
+                            organizationSwitcherPopoverPrimaryButton: 'bg-primary-500 hover:bg-primary-600 text-white'
                         }
                     }}
                 />

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,8 +7,9 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 const isPublicRoute = createRouteMatcher(['/api/webhook/clerk', '/api/uploadthing', '/sign-in(.*)', '/sign-up(.*)']);
 
 export default clerkMiddleware(async (auth, req) => {
-    if (isPublicRoute(req)) return; // if it's a public route, do nothing
-    await auth.protect(); // for any other route, require auth
+    if (!isPublicRoute(req)) {
+        await auth.protect();
+    }
 });
 
 export const config = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "sutram",
+    "name": "threadloom",
     "version": "0.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "sutram",
+            "name": "threadloom",
             "version": "0.1.0",
             "dependencies": {
                 "@clerk/nextjs": "^6.23.3",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "sutram",
+    "name": "threadloom",
     "version": "0.1.0",
     "private": true,
     "scripts": {


### PR DESCRIPTION
### Summary

1. Rebrand the app from Sutra/Sutram to ThreadLoom, updating package metadata, layout metadata, onboarding copy, navbar branding, and a comprehensive README rewrite with architecture diagram and contribution guide.
2. Restyle the Clerk OrganizationSwitcher to stay legible on the dark top bar, customizing hover/active states and popover colors.
3. Minor layout/middleware adjustments aligned with the rebrand.

### Testing

- npm run dev (visual verification of top bar + dropdown)
- Manual review of README rendering (Markdown preview)